### PR TITLE
Moved hardcoded server url to a buildConfig field

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -33,6 +35,10 @@ android {
                     "proguard-rules.pro"
                 )
             )
+            buildConfigField("String", "BOX_URL", "http://__deployed_box_url")
+        }
+        named("debug") {
+            buildConfigField("String", "BOX_URL", "\"${gradleLocalProperties(project.rootDir).getProperty("LOCAL_BOX_URL")}\"")
         }
     }
     compileOptions {

--- a/app/src/main/java/com/microsoft/research/karya/injection/RetrofitModule.kt
+++ b/app/src/main/java/com/microsoft/research/karya/injection/RetrofitModule.kt
@@ -1,6 +1,7 @@
 package com.microsoft.research.karya.injection
 
 import android.content.Context
+import com.microsoft.research.karya.BuildConfig
 import com.microsoft.research.karya.data.manager.AuthManager
 import com.microsoft.research.karya.data.manager.BaseUrlManager
 import com.microsoft.research.karya.data.remote.interceptors.HostSelectionInterceptor
@@ -40,9 +41,7 @@ class RetrofitModule {
     @Provides
     @Reusable
     @BaseUrl
-    fun provideBaseUrl(): String {
-        return "http://__url__"
-    }
+    fun provideBaseUrl(): String = BuildConfig.BOX_URL
 
     @Provides
     @Singleton


### PR DESCRIPTION
## Purpose/Description

Using server url as a build config field, allows us to use a custom server url in the local.properties file which will be picked up by debug build and the __deployed_box_url in release build Currently every time I checkout a new branch I would have to set server url in RetrofitModule, this way it would also not be required because local.properties do is a gitignore file

For eg: my local.properties file
```python
## This file must *NOT* be checked into Version Control Systems,
# as it contains information specific to your local configuration.
#
# Location of the SDK. This is only used by Gradle.
# For customization when using a Version Control System, please read the
# header note.
#Sat Oct 01 00:32:57 IST 2022
sdk.dir=/Users/divyansh/Library/Android/sdk

LOCAL_BOX_URL=http://192.168.0.103:6000
```


## Checklist
_Please, go through these checks before submitting the PR._
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)