### PR TITLE
Added timber logs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,6 +164,9 @@ dependencies {
     "largeImplementation" (Dependencies.Google.MLKit.faceDetectionPlayServices)
     "largeImplementation" (Dependencies.Google.MLKit.faceDetection)
     "largeImplementation" (Dependencies.ThirdParty.videoCompressor)
+
+    // Timber for logging
+    implementation(Dependencies.ThirdParty.timber)
 }
 
 kapt {

--- a/app/src/main/java/com/microsoft/research/karya/KaryaApp.kt
+++ b/app/src/main/java/com/microsoft/research/karya/KaryaApp.kt
@@ -1,9 +1,12 @@
 package com.microsoft.research.karya
 
 import android.app.Application
+import android.util.Log
 import androidx.work.Configuration
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.microsoft.research.karya.data.manager.SyncDelegatingWorkerFactory
 import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -12,5 +15,23 @@ class KaryaApp : Application(), Configuration.Provider {
     @Inject lateinit var workerFactory: SyncDelegatingWorkerFactory
 
     override fun getWorkManagerConfiguration(): Configuration =
-        Configuration.Builder().setMinimumLoggingLevel(android.util.Log.DEBUG).setWorkerFactory(workerFactory).build()
+        Configuration.Builder().setMinimumLoggingLevel(Log.DEBUG).setWorkerFactory(workerFactory).build()
+
+    override fun onCreate() {
+        super.onCreate()
+        /**
+         * For Debug builds, print the logs to the Logcat and
+         * for release builds only Log.ERROR will be sent to [FirebaseCrashlytics]
+         */
+        Timber.plant(if (BuildConfig.DEBUG) Timber.DebugTree() else CrashReportingTree())
+    }
+
+    private class CrashReportingTree : Timber.Tree() {
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            /** Send exception report only for Timber.e, Timber.v, d, i, w, a will be ignored by [FirebaseCrashlytics] */
+            if (priority == Log.ERROR && t != null) {
+                FirebaseCrashlytics.getInstance().recordException(t)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/microsoft/research/karya/data/manager/AuthManager.kt
+++ b/app/src/main/java/com/microsoft/research/karya/data/manager/AuthManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import javax.inject.Inject
 
 enum class AUTH_STATUS {
@@ -75,6 +76,7 @@ constructor(
                 setAuthStatus(AUTH_STATUS.LOGGED_IN)
             }
         } catch (e: NoWorkerException) {
+            Timber.w(e)
             setAuthStatus(AUTH_STATUS.LOGGED_OUT)
         }
     }

--- a/app/src/main/java/com/microsoft/research/karya/data/manager/ResourceManager.kt
+++ b/app/src/main/java/com/microsoft/research/karya/data/manager/ResourceManager.kt
@@ -1,6 +1,5 @@
 package com.microsoft.research.karya.data.manager
 
-import android.util.Log
 import com.microsoft.research.karya.data.repo.LanguageRepository
 import com.microsoft.research.karya.utils.FileUtils
 import com.microsoft.research.karya.utils.Result
@@ -10,6 +9,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.singleOrNull
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
@@ -42,7 +42,7 @@ constructor(
                 .getLanguageAssets(accessCode, language)
                 .flowOn(Dispatchers.IO)
                 .catch {
-                    Log.d("ResourceManager", "Error downloading files for language: $language")
+                    Timber.d("Error downloading files for language: $language")
                     emit(Result.Error(it))
                     return@catch
                 }

--- a/app/src/main/java/com/microsoft/research/karya/data/repo/AssignmentRepository.kt
+++ b/app/src/main/java/com/microsoft/research/karya/data/repo/AssignmentRepository.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 import okhttp3.MultipartBody
+import timber.log.Timber
 import javax.inject.Inject
 
 private const val INITIAL_TIME = "1970-01-01T00:00:00Z"
@@ -267,7 +268,9 @@ constructor(
                     reportSummary.volume += volume
                     count += 1
                 }
-            } catch (e: Exception) {}
+            } catch (e: Exception) {
+                Timber.w(e)
+            }
         }
         if (count > 0) {
             reportSummary.accuracy /= (count * 2.0f / 5)
@@ -293,7 +296,9 @@ constructor(
                         summary[key] = summary[key]!! + report.get(key).asFloat
                         count[key] = count[key]!! + 1
                     }
-                } catch (e: Exception) {}
+                } catch (e: Exception) {
+                    Timber.w(e)
+                }
             }
         }
 
@@ -320,7 +325,9 @@ constructor(
             if (ar.report != null && !ar.report.isJsonNull) {
                 try {
                     taskReports[ar.task_id]!!.add(ar.report.asJsonObject)
-                } catch (e: Exception) {}
+                } catch (e: Exception) {
+                    Timber.w(e)
+                }
             }
         }
 
@@ -362,7 +369,9 @@ constructor(
                 if (ar.report != null && !ar.report.isJsonNull) {
                     try {
                         scenarioReports[ar.scenario_name]!!.add(ar.report.asJsonObject)
-                    } catch (e: Exception) {}
+                    } catch (e: Exception) {
+                        Timber.w(e)
+                    }
                 }
             }
         }
@@ -378,7 +387,9 @@ constructor(
                 val reports = scenarioReports[scenario] ?: mutableListOf()
                 val summary = reduceTaskReports(reports, arrayListOf("accuracy"), 5.0f)
                 scenarioSummary[scenario] = summary
-            } catch (e: Exception) {}
+            } catch (e: Exception) {
+                Timber.w(e)
+            }
         }
         return scenarioSummary.toMap()
     }

--- a/app/src/main/java/com/microsoft/research/karya/data/repo/PaymentRepository.kt
+++ b/app/src/main/java/com/microsoft/research/karya/data/repo/PaymentRepository.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import javax.inject.Inject
 
 class PaymentRepository
@@ -33,6 +34,7 @@ constructor(
             val ifsc = try {
                 paymentInfoResponse.meta!!.account.ifsc!!
             } catch (e: Exception) {
+                Timber.e(e)
                 ""
             }
 

--- a/app/src/main/java/com/microsoft/research/karya/ui/MainActivity.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/MainActivity.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
 
@@ -48,6 +49,7 @@ class MainActivity : AppCompatActivity() {
                 val languageCode = worker.language
                 setActivityLocale(languageCode)
             } catch (e: Throwable) {
+                Timber.w(e)
                 // No logged in worker. Ignore
             }
         }

--- a/app/src/main/java/com/microsoft/research/karya/ui/base/BaseFragment.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/base/BaseFragment.kt
@@ -18,6 +18,7 @@ import com.microsoft.research.karya.utils.extensions.finish
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 abstract class BaseFragment : Fragment {
@@ -76,6 +77,7 @@ abstract class BaseFragment : Fragment {
                 }
             } catch (e: Exception) {
                 // Ignore exceptions
+                Timber.w(e)
             }
         }
     }

--- a/app/src/main/java/com/microsoft/research/karya/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/dashboard/DashboardViewModel.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.math.BigInteger
 import java.security.MessageDigest
 import java.util.*
@@ -70,6 +71,7 @@ constructor(
                     }
                 }
             } catch (e: Exception) {
+                Timber.w(e)
                 _workFromCenterUser.value = false
             }
         }
@@ -150,9 +152,12 @@ constructor(
 
                     val tempList = mutableListOf<TaskInfo>()
                     taskList.forEach { taskRecord ->
+                        // TODO: Here only NPE are expected in the case when the key do not exist
+                        //      in the JSON object so can be simply "?.asString ?: null", can't be?
                         val taskInstruction = try {
                             taskRecord.params.asJsonObject.get("instruction").asString
                         } catch (e: Exception) {
+                            Timber.e(e)
                             null
                         }
                         val taskId = taskRecord.id
@@ -179,7 +184,10 @@ constructor(
                         )
                     _dashboardUiState.value = success
                 }
-                .catch { _dashboardUiState.value = DashboardUiState.Error(it) }
+                .catch {
+                    Timber.w(it)
+                    _dashboardUiState.value = DashboardUiState.Error(it)
+                }
                 .collect()
         }
     }

--- a/app/src/main/java/com/microsoft/research/karya/ui/homeScreen/HomeScreenViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/homeScreen/HomeScreenViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -86,12 +87,14 @@ constructor(
             val name = try {
                 worker.profile!!.asJsonObject.get("name").asString
             } catch (e: Exception) {
+                Timber.w(e)
                 "No Name"
             }
 
             val phoneNumber = try {
                 worker.phoneNumber!!
             } catch (e: Exception) {
+                Timber.w(e)
                 "9999999999"
             }
 
@@ -106,6 +109,7 @@ constructor(
                 _points.value = try {
                     workerRepository.getXPPoints(worker.id)!!
                 } catch (e: Exception) {
+                    Timber.w(e)
                     0
                 }
             }
@@ -126,21 +130,25 @@ constructor(
             val recordingAccuracy = try {
                 scenarioSummary[ScenarioType.SPEECH_DATA]!!.get("accuracy").asFloat
             } catch (e: Exception) {
+                Timber.w(e)
                 0.0f
             }
             val transcriptionAccuracy = try {
                 scenarioSummary[ScenarioType.SPEECH_TRANSCRIPTION]!!.get("accuracy").asFloat
             } catch (e: Exception) {
+                Timber.w(e)
                 0.0f
             }
             val typingAccuracy = try {
                 scenarioSummary[ScenarioType.SENTENCE_CORPUS]!!.get("accuracy").asFloat
             } catch (e: Exception) {
+                Timber.w(e)
                 0.0f
             }
             val imageAnnotationAccuracy = try {
                 scenarioSummary[ScenarioType.IMAGE_ANNOTATION]!!.get("accuracy").asFloat
             } catch (e: Exception) {
+                Timber.w(e)
                 0.0f
             }
 

--- a/app/src/main/java/com/microsoft/research/karya/ui/onboarding/accesscode/AccessCodeDecoder.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/onboarding/accesscode/AccessCodeDecoder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.microsoft.research.karya.BuildConfig
 import com.microsoft.research.karya.data.exceptions.InvalidAccessCodeException
 import org.json.JSONObject
+import timber.log.Timber
 import kotlin.properties.Delegates
 
 private const val VERSION_0: Long = 0
@@ -48,7 +49,7 @@ class AccessCodeDecoder {
 
                 return url
             } catch (e: Throwable) {
-                // TODO: Log the error somewhere
+                Timber.e(e)
                 return DEFAULT_URL
             }
         }

--- a/app/src/main/java/com/microsoft/research/karya/ui/onboarding/accesscode/AccessCodeViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/onboarding/accesscode/AccessCodeViewModel.kt
@@ -9,6 +9,7 @@ import com.microsoft.research.karya.data.repo.WorkerRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -39,6 +40,7 @@ constructor(
                 _accessCodeEffects.emit(AccessCodeEffects.Navigate)
             }
             .catch { exception ->
+                Timber.e(exception)
                 _accessCodeUiState.value = AccessCodeUiState.Error(exception)
             }
             .launchIn(viewModelScope)

--- a/app/src/main/java/com/microsoft/research/karya/ui/onboarding/login/otp/OTPViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/onboarding/login/otp/OTPViewModel.kt
@@ -9,6 +9,7 @@ import com.microsoft.research.karya.data.repo.WorkerRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -49,7 +50,10 @@ constructor(
             workerRepository
                 .resendOTP(accessCode = worker.accessCode, phoneNumber = worker.phoneNumber)
                 .onEach { _otpUiState.value = OTPUiState.Initial }
-                .catch { throwable -> _otpUiState.value = OTPUiState.Error(throwable) }
+                .catch { throwable ->
+                    Timber.e(throwable)
+                    _otpUiState.value = OTPUiState.Error(throwable)
+                }
                 .collect()
         }
     }
@@ -73,7 +77,10 @@ constructor(
                         _otpEffects.emit(OTPEffects.NavigateToProfile)
                     }
                 }
-                .catch { throwable -> _otpUiState.value = OTPUiState.Error(throwable) }
+                .catch { throwable ->
+                    Timber.e(throwable)
+                    _otpUiState.value = OTPUiState.Error(throwable)
+                }
                 .collect()
         }
     }

--- a/app/src/main/java/com/microsoft/research/karya/ui/onboarding/login/phone/PhoneNumberViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/onboarding/login/phone/PhoneNumberViewModel.kt
@@ -8,6 +8,7 @@ import com.microsoft.research.karya.data.repo.WorkerRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -51,7 +52,10 @@ constructor(
                     _phoneNumberUiState.value = PhoneNumberUiState.Success
                     _phoneNumberEffects.emit(PhoneNumberEffects.Navigate)
                 }
-                .catch { throwable -> _phoneNumberUiState.value = PhoneNumberUiState.Error(throwable) }
+                .catch { throwable ->
+                    Timber.e(throwable)
+                    _phoneNumberUiState.value = PhoneNumberUiState.Error(throwable)
+                }
                 .collect()
         }
     }

--- a/app/src/main/java/com/microsoft/research/karya/ui/onboarding/login/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/onboarding/login/profile/ProfileViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -84,6 +85,7 @@ constructor(
                     handleNavigation()
                 }
                 .catch { throwable ->
+                    Timber.e(throwable)
                     _profileUiState.value = ProfileUiState.Error(throwable)
                 }
                 .collect()

--- a/app/src/main/java/com/microsoft/research/karya/ui/payment/dashboard/PaymentDashboardViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/payment/dashboard/PaymentDashboardViewModel.kt
@@ -11,10 +11,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
@@ -91,6 +91,7 @@ constructor(
 
             combinedFlow
                 .catch { e ->
+                    Timber.e(e)
                     _uiStateFlow.update {
                         it.copy(
                             isLoading = false,

--- a/app/src/main/java/com/microsoft/research/karya/ui/payment/details/bank/PaymentDetailBankViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/payment/details/bank/PaymentDetailBankViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -58,7 +59,8 @@ constructor(
             val paymentAccountRequest = PaymentAccountRequest(account = account, name = name, type = "bank_account")
             paymentRepository
                 .addAccount(idToken, paymentAccountRequest)
-                .catch {
+                .catch { throwable ->
+                    Timber.e(throwable)
                     _uiStateFlow.update { it.copy(isLoading = false, errorMessage = "Some error occurRed") }
                     _navigationFlow.emit(PaymentDetailNavigation.FAILURE)
                 }

--- a/app/src/main/java/com/microsoft/research/karya/ui/payment/details/upi/PaymentDetailUPIViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/payment/details/upi/PaymentDetailUPIViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -56,7 +57,8 @@ constructor(
             val paymentAccountRequest = PaymentAccountRequest(account = account, name = name, type = "vpa")
             paymentRepository
                 .addAccount(idToken, paymentAccountRequest)
-                .catch {
+                .catch { throwable ->
+                    Timber.e(throwable)
                     _uiStateFlow.update { it.copy(isLoading = false, errorMessage = "Some error occurRed") }
                     _navigationFlow.emit(PaymentDetailNavigation.FAILURE)
                 }

--- a/app/src/main/java/com/microsoft/research/karya/ui/payment/transactions/PaymentTransactionViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/payment/transactions/PaymentTransactionViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
@@ -37,7 +38,10 @@ constructor(private val authManager: AuthManager, private val paymentRepository:
 
             paymentRepository
                 .getTransactions(idToken, worker.id)
-                .catch { _uiStateFlow.update { it.copy(isLoading = false, errorMessage = "Error fetching transactions") } }
+                .catch { throwable ->
+                    Timber.e(throwable)
+                    _uiStateFlow.update { it.copy(isLoading = false, errorMessage = "Error fetching transactions") }
+                }
                 .collect { list ->
                     val transactionList =
                         list.map { transaction ->

--- a/app/src/main/java/com/microsoft/research/karya/ui/payment/verification/PaymentVerificationViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/payment/verification/PaymentVerificationViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -44,7 +45,8 @@ constructor(
 
             paymentRepository
                 .getCurrentAccount(idToken)
-                .catch {
+                .catch { throwable ->
+                    Timber.e(throwable)
                     _uiStateFlow.update {
                         it.copy(isLoading = false, errorMessage = "Error connecting to server", requestProcessed = false)
                     }
@@ -103,7 +105,10 @@ constructor(
             _uiStateFlow.update { it.copy(isLoading = true) }
             paymentRepository
                 .verifyAccount(idToken, accountRecordId, confirm)
-                .catch { _navigationFlow.emit(PaymentVerificationNavigation.FAILURE) }
+                .catch { throwable ->
+                    Timber.e(throwable)
+                    _navigationFlow.emit(PaymentVerificationNavigation.FAILURE)
+                }
                 .collect { paymentInfoResponse ->
                     paymentRepository.updatePaymentRecord(worker.id, paymentInfoResponse)
                     when (paymentInfoResponse.status) {

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/common/BaseFeedbackRendererViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/common/BaseFeedbackRendererViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import timber.log.Timber
 import java.io.File
 import kotlin.properties.Delegates
 
@@ -120,6 +121,7 @@ constructor(
                 outputFilesDict.keySet().forEach { k -> outputFiles.add(outputFilesDict.get(k).asString) }
                 outputFiles
             } catch (e: Exception) {
+                Timber.w(e)
                 arrayListOf<String>()
             }
         assignmentOutputFiles.forEach {

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/common/BaseMTRendererViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/common/BaseMTRendererViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 import java.io.File
 import java.util.*
 
@@ -324,6 +325,7 @@ abstract class BaseMTRendererViewModel(
                     null
                 }
             } catch (e: Exception) {
+                Timber.e(e)
                 null
             }
 

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageAnnotation/ImageAnnotationFragment.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageAnnotation/ImageAnnotationFragment.kt
@@ -29,6 +29,7 @@ import com.microsoft.research.karya.utils.spotlight.TargetData
 import com.takusemba.spotlight.shape.Circle
 import com.takusemba.spotlight.shape.RoundedRectangle
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 import java.util.*
 import kotlin.collections.HashMap
 
@@ -70,6 +71,7 @@ class ImageAnnotationFragment : BaseMTRendererFragment(R.layout.microtask_image_
         val instruction = try {
             viewModel.task.params.asJsonObject.get("instruction").asString
         } catch (e: Exception) {
+            Timber.e(e, "No task instructions were found")
             getString(R.string.image_annotation_instruction)
         }
         with(binding) {
@@ -82,6 +84,7 @@ class ImageAnnotationFragment : BaseMTRendererFragment(R.layout.microtask_image_
             labels = try {
                 viewModel.task.params.asJsonObject.get("labels").asJsonArray.map { it.asString }
             } catch (e: Exception) {
+                Timber.e(e, "No labels for image annotation were found")
                 arrayListOf()
             }
             // Create label detail array // TODO: It is throwing ArrayIndexOutOfBounds (colors is always of size 4 but labels not)

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageAnnotationVerification/ImageAnnotationVerificationFragment.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageAnnotationVerification/ImageAnnotationVerificationFragment.kt
@@ -21,6 +21,7 @@ import com.microsoft.research.karya.utils.extensions.observe
 import com.microsoft.research.karya.utils.extensions.viewBinding
 import com.microsoft.research.karya.utils.extensions.viewLifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class ImageAnnotationVerificationFragment : BaseMTRendererFragment(R.layout.microtask_image_annotation_verification_fragment) {
@@ -49,6 +50,7 @@ class ImageAnnotationVerificationFragment : BaseMTRendererFragment(R.layout.micr
         val instruction = try {
             viewModel.task.params.asJsonObject.get("instruction").asString
         } catch (e: Exception) {
+            Timber.e(e, "No task instructions were found")
             getString(R.string.image_annotation_instruction)
         }
         with(binding) {

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageAnnotationVerification/ImageAnnotationVerificationViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageAnnotationVerification/ImageAnnotationVerificationViewModel.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -63,12 +64,14 @@ constructor(
                 currentMicroTask.input.asJsonObject.getAsJsonObject("files").get("image").asString
             microtaskInputContainer.getMicrotaskInputFilePath(currentMicroTask.id, imageFileName)
         } catch (e: Exception) {
+            Timber.w(e, "Error fetching file names from input")
             ""
         }
         // Get image annotation type
         val annotationTypeString = try {
             currentMicroTask.input.asJsonObject.getAsJsonObject("data").get("annotationType").asString
         } catch (e: Exception) {
+            Timber.w(e, "No annotationType found")
             "RECTANGLE"
         }
 
@@ -79,6 +82,7 @@ constructor(
         numberOfSides = try {
             currentMicroTask.input.asJsonObject.getAsJsonObject("data").get("numberOfSides").asInt
         } catch (e: Exception) {
+            Timber.w(e)
             // Since default shape is rectangle
             4
         }
@@ -133,6 +137,7 @@ constructor(
         val annotations = try {
             currentMicroTask.input.asJsonObject.getAsJsonObject("data").getAsJsonObject("annotations")
         } catch (e: Exception) {
+            Timber.w(e)
             JsonObject()
         }
 

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageTranscription/ImageTranscriptionViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/imageTranscription/ImageTranscriptionViewModel.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -56,6 +57,7 @@ constructor(
                 val imageFileName = currentMicroTask.input.asJsonObject.getAsJsonObject("files").get("image").asString
                 microtaskInputContainer.getMicrotaskInputFilePath(currentMicroTask.id, imageFileName)
             } catch (e: Exception) {
+                Timber.w(e)
                 ""
             }
     }

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/sentenceCorpus/SentenceCorpusViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/sentenceCorpus/SentenceCorpusViewModel.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 import kotlin.properties.Delegates
 
@@ -60,6 +61,7 @@ constructor(
         limit = try {
             currentMicroTask.input.asJsonObject.getAsJsonObject("data").get("limit").asInt
         } catch (e: Exception) {
+            Timber.w(e)
             999999
         }
 

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/sentenceValidation/SentenceValidationFragment.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/sentenceValidation/SentenceValidationFragment.kt
@@ -11,6 +11,7 @@ import com.microsoft.research.karya.databinding.MicrotaskSentenceValidationBindi
 import com.microsoft.research.karya.ui.scenarios.common.BaseMTRendererFragment
 import com.microsoft.research.karya.utils.extensions.*
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class SentenceValidationFragment : BaseMTRendererFragment(R.layout.microtask_sentence_validation) {
@@ -41,6 +42,7 @@ class SentenceValidationFragment : BaseMTRendererFragment(R.layout.microtask_sen
                 val instruction = viewModel.task.params.asJsonObject.get("instruction").asString
                 instructionTv.text = instruction
             } catch (e: Exception) {
+                Timber.w(e)
                 instructionTv.gone()
             }
         }

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/speechData/SpeechDataMainViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/speechData/SpeechDataMainViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import timber.log.Timber
 import java.io.DataOutputStream
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -209,6 +210,7 @@ constructor(
         compressAudio = try {
             task.params.asJsonObject.get("compress").asBoolean
         } catch (e: Exception) {
+            Timber.w(e)
             false
         }
 
@@ -221,6 +223,7 @@ constructor(
                 else -> 44100
             }
         } catch (e: Exception) {
+            Timber.w(e)
             44100
         }
 
@@ -232,6 +235,7 @@ constructor(
                 else -> AudioFormat.ENCODING_PCM_16BIT
             }
         } catch (e: Exception) {
+            Timber.w(e)
             AudioFormat.ENCODING_PCM_16BIT
         }
 
@@ -288,6 +292,7 @@ constructor(
         allowSkipping = try {
             task.params.asJsonObject.get("allowSkipping").asBoolean
         } catch (e: Exception) {
+            Timber.w(e)
             false
         }
 
@@ -1095,6 +1100,7 @@ constructor(
                     val readBytes = try {
                         audioRecorder!!.read(currentBuffer, consumedBytes, remainingBytes)
                     } catch (e: Exception) {
+                        Timber.w(e)
                         break
                     }
 
@@ -1132,6 +1138,7 @@ constructor(
                     try {
                         readBytes = audioRecorder!!.read(data, currentRecordBufferConsumed, remainingSpace)
                     } catch (e: Exception) {
+                        Timber.w(e)
                         // Exception likely caused by recording job getting cancelled
                         break
                     }
@@ -1208,6 +1215,7 @@ constructor(
                             totalRecordedBytes += currentRecordBufferConsumed
                         }
                     } catch (e: Exception) {
+                        Timber.w(e)
                         // Ignore (rare) errors
                     }
 

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/speechTranscription/SpeechTranscriptionViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/speechTranscription/SpeechTranscriptionViewModel.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
 
@@ -117,6 +118,7 @@ constructor(
             // Set andexo player recording file if valid file
             _recordingFilePath.value = recordingFile
         } catch (e: Exception) {
+            Timber.w(e)
             showErrorWithDialogBox("Corrupt audio file")
             handleCorruptAudio()
             return
@@ -132,6 +134,7 @@ constructor(
                 true
             }
         } catch (e: Exception) {
+            Timber.w(e)
             true
         }
 
@@ -143,6 +146,7 @@ constructor(
                 ""
             }
         } catch (e: Exception) {
+            Timber.w(e)
             ""
         }
 
@@ -157,6 +161,7 @@ constructor(
             val outputTranscript = try {
                 currentAssignment.output.asJsonObject.get("data").asJsonObject.get("transcription").asString
             } catch (e: Exception) {
+                Timber.w(e)
                 ""
             }
             _transcriptionText.value = outputTranscript

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/speechVerification/SpeechVerificationViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/speechVerification/SpeechVerificationViewModel.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.util.*
 import javax.inject.Inject
 
@@ -122,6 +123,7 @@ constructor(
         _rateOnlyAccuracy.value = try {
             task.params.asJsonObject.get("onlyAccuracy").asBoolean
         } catch (e: Exception) {
+            Timber.w(e)
             false
         }
 
@@ -155,6 +157,7 @@ constructor(
 
             setActivityState(ActivityState.WAIT_FOR_PLAY)
         } catch (exception: Exception) {
+            Timber.w(exception)
             // Alert dialog
             showErrorWithDialogBox("Audio file is corrupt")
         }
@@ -370,6 +373,7 @@ constructor(
                     try {
                         mediaPlayer?.currentPosition
                     } catch (e: Exception) {
+                        Timber.w(e)
                         null
                     }
                 _playbackProgress.value = currentPosition ?: _playbackProgress.value

--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/transliteration/TransliterationViewModel.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/transliteration/TransliterationViewModel.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 import kotlin.properties.Delegates
 
@@ -82,18 +83,21 @@ constructor(
             try {
                 task.params.asJsonObject.get("allowValidation").asBoolean
             } catch (e: Exception) {
+                Timber.w(e)
                 false
             }
         mlFeedback =
             try {
                 task.params.asJsonObject.get("mlFeedback").asBoolean
             } catch (e: Exception) {
+                Timber.w(e)
                 false
             }
         variantLimitTask =
             try {
                 task.params.asJsonObject.get("limit").asInt
             } catch (e: Exception) {
+                Timber.w(e)
                 2
             }
     }
@@ -108,6 +112,7 @@ constructor(
             try {
                 currentMicroTask.input.asJsonObject.getAsJsonObject("data").get("limit").asInt
             } catch (e: Exception) {
+                Timber.w(e)
                 variantLimitTask
             }
 
@@ -115,6 +120,7 @@ constructor(
             try {
                 currentMicroTask.input.asJsonObject.getAsJsonObject("data").get("variants").asJsonObject
             } catch (e: Exception) {
+                Timber.w(e)
                 JsonObject()
             }
         val temp = mutableMapOf<String, WordDetail>()

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -117,6 +117,7 @@ object Dependencies {
     const val volley = "com.mcxiaoke.volley:library:1.0.19" // why this one? This is Deprecated
     const val magicalExoPlayer = "com.github.HamidrezaAmz:MagicalExoPlayer:2.0.6"
     const val videoCompressor = "com.github.fishwjy:VideoCompressor:master-SNAPSHOT"
+    const val timber = "com.jakewharton.timber:timber:5.0.1"
 
     object Retrofit {
       private const val version = "2.9.0"


### PR DESCRIPTION
Timber gives us a better way to log errors or debug statements over the default logging utility. In the PR, the library has been configured in such a way that for debug builds all the logs will be printed to the logcat and for the release builds only statements logged with the priority ERROR will be sent to Crashlytics. It is important to send only a limited number of logs to Crashlytics as it remembers only the last eight reports.

A general rule of thumb that I followed is the exceptions that might occur due to backend response and our logic should be reported so that we can update or fix such things. And exceptions such as IOExceptions (during disk IO) or NetworkExceptions can be ignored as this is something that is dependent on runtime and cannot be handled by us.

Critical exceptions are logged with ERROR
Exceptions that are critical but not needed to send to Crashlytics are logged with priority WARN. 
Exceptions of least priority are just logged as DEBUG.

## Logs are sent to firebase as expected 
<img width="1440" alt="Screenshot 2022-11-02 at 6 27 49 PM" src="https://user-images.githubusercontent.com/69595691/199498143-c71f8f98-207d-4fa7-a260-57c7dd6b5d11.png">

