### PR TITLE
refactor: update gradle configuration with latest android's standards

### DIFF
--- a/app/src/main/java/com/microsoft/research/karya/ui/scenarios/transliteration/TransliterationMainFragment.kt
+++ b/app/src/main/java/com/microsoft/research/karya/ui/scenarios/transliteration/TransliterationMainFragment.kt
@@ -143,6 +143,7 @@ class TransliterationMainFragment :
                     WordVerificationStatus.VALID -> {
                         atleastOneValidNew = true
                     }
+                    else -> {}
                 }
             }
             if (!noUnknowns) {
@@ -180,6 +181,7 @@ class TransliterationMainFragment :
                         WordVerificationStatus.VALID -> setValidUI(itemBinding)
                         WordVerificationStatus.INVALID -> setInvaidUI(itemBinding)
                         WordVerificationStatus.UNKNOWN -> setUnknownUI(itemBinding)
+                        else -> {}
                     }
 
                     root.setOnClickListener {
@@ -196,6 +198,7 @@ class TransliterationMainFragment :
                                 word,
                                 WordVerificationStatus.VALID
                             )
+                            else -> {}
                         }
                     }
                     verifyFlowLayout.addView(root)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,35 +1,25 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        jcenter()
-
-        // TODO: Remove JCenter
-        @Suppress("JcenterRepositoryObsolete")
-        jcenter {
-            content {
-                //  org.jetbrains.trove4j is only available in JCenter
-                includeGroup("org.jetbrains.trove4j")
-            }
-        }
-    }
-
-    // TODO: Move to plugins block (recommended from AGP 7.3)
     dependencies {
-        classpath(Plugins.agp)
-        classpath(Plugins.kotlin)
         classpath(Plugins.gms)
         classpath(Plugins.crashlytics)
         classpath(Plugins.safeArgs)
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle.kts files
     }
 }
 
 plugins {
+    /**
+     * You should use `apply false` in the top-level build.gradle file
+     * to add a Gradle plugin as a build dependency, but not apply it to the
+     * current (root) project. You should not use `apply false` in sub-projects.
+     * For more information, see https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
+     */
+    id(Plugin.AndroidApplication.id) version Plugin.AndroidApplication.version apply false
+    id(Plugin.AndroidLibrary.id) version Plugin.AndroidLibrary.version apply false
+    id(Plugin.KotlinAndroid.id) version Plugin.KotlinAndroid.version apply false
     id(Plugin.KtLint.id) version Plugin.KtLint.version
     id(Plugin.Hilt.id) version Plugin.Hilt.version apply false
 }
@@ -40,6 +30,9 @@ apply {
 
 allprojects {
 
+    /**
+     * Applying ktlint plugin is all modules
+     */
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
     ktlint {
         /**
@@ -49,23 +42,6 @@ allprojects {
          * Once this issue has been addressed we can remove 'filename' from the list
          */
         disabledRules.set(listOf("no-wildcard-imports", "filename"))
-    }
-
-    repositories {
-        google()
-        mavenCentral()
-        jcenter()
-        maven(url = "https://jitpack.io")
-
-        // TODO: Remove JCenter
-        @Suppress("JcenterRepositoryObsolete")
-        jcenter {
-            content {
-                includeGroup("com.amitshekhar.android")
-                includeGroup("com.kofigyan.stateprogressbar")
-                includeGroup("org.jetbrains.trove4j")
-            }
-        }
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -18,8 +18,10 @@ object Plugins {
   const val safeArgs = "androidx.navigation:navigation-safe-args-gradle-plugin:$NAVIGATION_VERSION"
 }
 
-// TODO: Rename to Plugins once root build.gradle is migrated from using classpath to plugins
 sealed class Plugin(val id: String, val version: String) {
+  object KotlinAndroid : Plugin("org.jetbrains.kotlin.android", "1.7.20")
+  object AndroidApplication: Plugin("com.android.application", "7.3.1")
+  object AndroidLibrary: Plugin("com.android.library", "7.3.1")
   object Hilt : Plugin("com.google.dagger.hilt.android", HILT_VERSION)
   object KtLint : Plugin("org.jlleitschuh.gradle.ktlint", KT_LINT_VERSION)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,43 @@
+// https://developer.android.com/studio/build#settings-file
+pluginManagement {
+
+    /**
+     * The pluginManagement {repositories {...}} block configures the
+     * repositories Gradle uses to search or download the Gradle plugins and
+     * their transitive dependencies.The code below
+     * defines the Gradle Plugin Portal, Google's Maven repository, the Maven Central Repository
+     * and JCenter as the repositories Gradle should use to look for its dependencies.
+     */
+
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        /**
+         * TODO: Remove jcenter,
+         * Libraries com.kofigyan.stateprogressbar and com.amitshekhar.android:debug-db are available on jcenter() only.
+         * Once project is migrated to Jetpack Compose, stateprogressbar won't be required anymore.
+         */
+        jcenter()
+    }
+}
+
+dependencyResolutionManagement {
+
+    /**
+     * The dependencyResolutionManagement { repositories {...}}
+     * block is where we configure the repositories and dependencies used by
+     * all modules in your project, such as libraries that we are using to
+     * create our application.
+     */
+
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        jcenter()
+        maven(url = "https://jitpack.io")
+    }
+}
+rootProject.name = "Karya"
 include(":app")


### PR DESCRIPTION
for latest info, see https://developer.android.com/studio/build

- Kotlin 1.7.20 requires when blocks to be mutually exhaustive, so added `else -> {}`
- Adding latest libraries required newer Kotlin version, so using 1.7.20
- I was thinking for compose components to have a separate android library module that requires newer Gradle configuration, so this migration is important for that.

This configuration is also comes as default with latest android studio.